### PR TITLE
Replace deprecated criterion black_box with std::hint

### DIFF
--- a/benches/performance.rs
+++ b/benches/performance.rs
@@ -1,8 +1,9 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use intent_engine::db::{create_pool, run_migrations};
 use intent_engine::events::EventManager;
 use intent_engine::report::ReportManager;
 use intent_engine::tasks::TaskManager;
+use std::hint::black_box;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 


### PR DESCRIPTION
Replace deprecated criterion::black_box with std::hint::black_box as recommended. This resolves the 5 compilation errors in the performance benchmarks.

- Removed black_box from criterion imports
- Added use std::hint::black_box import
- All existing black_box calls now use the std::hint version