### PR TITLE
feat: 添加 --version 支持

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(name = "intent-engine")]
 #[command(about = "A command-line database service for tracking strategic intent", long_about = None)]
+#[command(version)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,


### PR DESCRIPTION
- 在 CLI 中添加 #[command(version)] 属性
- 支持 --version 和 -V 短选项
- 自动显示当前版本号 (v0.1.6)

修复用户报告的问题: intent-engine --version 未找到参数