### PR TITLE
docs: 更新所有文档以反映 task done 命令的正确语义

### DIFF
--- a/.claude-code/intent-engine.skill.md
+++ b/.claude-code/intent-engine.skill.md
@@ -16,8 +16,8 @@ intent-engine task start 1 --with-events
 echo "Using Passport.js for OAuth strategy implementation" | \
   intent-engine event add --task-id 1 --type decision --data-stdin
 
-# Complete the task
-intent-engine task done 1
+# Complete the task (task 1 is currently focused)
+intent-engine task done
 ```
 
 ## Core Workflow
@@ -115,10 +115,12 @@ Event types: `decision`, `blocker`, `milestone`, `discussion`, `note`
 Only when all objectives achieved and all subtasks done:
 
 ```bash
-intent-engine task done <ID>
+intent-engine task done
 ```
 
-System enforces: parent can't complete until all children are done.
+**Important**: This command operates on the current focused task only. It does not accept an ID parameter.
+- If you need to complete a non-current task, first switch to it: `intent-engine task switch <ID>` or `intent-engine current --set <ID>`
+- System enforces: parent can't complete until all children are done.
 
 ### 8. Generate Reports (Token-Efficient)
 
@@ -166,12 +168,12 @@ intent-engine task spawn-subtask --name "Sub-problem A"
 # Discover nested sub-problem
 intent-engine task spawn-subtask --name "Sub-sub-problem"
 
-# Complete from deepest to shallowest
-intent-engine task done 3
-intent-engine task switch 2
-intent-engine task done 2
-intent-engine task switch 1
-intent-engine task done 1
+# Complete from deepest to shallowest (each spawn-subtask auto-focuses the subtask)
+intent-engine task done  # Completes current (sub-sub-problem)
+intent-engine task switch 2  # Switch to parent
+intent-engine task done  # Completes current (sub-problem A)
+intent-engine task switch 1  # Switch to root
+intent-engine task done  # Completes current (parent task)
 ```
 
 ### Pattern 3: Recover Context After Interruption

--- a/docs/en/guide/command-reference-full.md
+++ b/docs/en/guide/command-reference-full.md
@@ -438,13 +438,15 @@ intent-engine task start 1 --with-events | jq '.events_summary.recent_events'
 
 Atomic operation: check if all subtasks are complete, then mark task as "done".
 
+This command does not accept any ID parameter. It operates on the current focused task (`current_task_id`) only.
+
 **Usage:**
 ```bash
 intent-engine task done
 ```
 
 **Parameters:**
-- `<ID>` - Task ID (required)
+- None (operates on current focused task)
 
 **Examples:**
 ```bash

--- a/docs/en/guide/the-intent-engine-way.md
+++ b/docs/en/guide/the-intent-engine-way.md
@@ -199,12 +199,12 @@ echo "Need to complete domain ownership verification before creating OAuth app" 
 
 intent-engine task spawn-subtask --name "Complete domain ownership verification"
 
-# Complete deepest subtask
-intent-engine task done <grandchild-task-id>
+# Complete deepest subtask (it's now focused after spawn-subtask)
+intent-engine task done
 
 # Switch back to parent task and continue
 intent-engine task switch <child-task-id>
-intent-engine task done <child-task-id>
+intent-engine task done
 
 # Finally complete root task
 intent-engine task switch 42
@@ -396,10 +396,10 @@ echo "Need to use profiler to locate memory leak source" | \
 
 intent-engine task spawn-subtask --name "Analyze memory usage with Valgrind"
 
-# 5.2 Complete diagnosis
+# 5.2 Complete diagnosis (subtask is now focused, complete it)
 echo "Problem found: WebSocket connections not properly closed" | \
   intent-engine event add --task-id <subtask-id> --type milestone --data-stdin
-intent-engine task done <subtask-id>
+intent-engine task done
 
 # 5.3 Switch back and complete main task
 intent-engine task switch 3

--- a/docs/zh-CN/guide/ai-quick-guide.md
+++ b/docs/zh-CN/guide/ai-quick-guide.md
@@ -40,7 +40,7 @@ echo "Decision/blocker/milestone..." | \
 
 ### Complete (Enforces Hierarchy)
 ```bash
-intent-engine task done <ID>  # Fails if subtasks incomplete
+intent-engine task done  # Completes current focused task, fails if subtasks incomplete
 ```
 
 ### Get Summary (Token-Efficient)
@@ -65,12 +65,12 @@ echo "Chose Passport.js for OAuth strategies" | \
 # 4. Hit sub-problem? Create & auto-switch
 intent-engine task spawn-subtask --name "Configure Google OAuth app"
 
-# 5. Complete child, switch back to parent
-intent-engine task done 2
+# 5. Complete child (child is now focused after spawn-subtask), switch back to parent
+intent-engine task done
 intent-engine task switch 1
 
 # 6. Complete parent
-intent-engine task done 1
+intent-engine task done
 ```
 
 ## Batch Problem Handling

--- a/docs/zh-CN/guide/the-intent-engine-way.md
+++ b/docs/zh-CN/guide/the-intent-engine-way.md
@@ -416,8 +416,8 @@ echo "问题原因：UserService.getUser() 未检查返回值是否为 null
 # 4.2 执行修复
 # ... 修改代码 ...
 
-# 4.3 完成任务
-intent-engine task done 1
+# 4.3 完成任务（任务1当前是焦点，直接完成）
+intent-engine task done
 
 # 5. 处理第二个任务（包含子任务）
 intent-engine task switch 3
@@ -428,15 +428,15 @@ echo "需要先使用 profiler 定位内存泄漏源" | \
 
 intent-engine task spawn-subtask --name "使用 Valgrind 分析内存使用"
 
-# 5.2 完成诊断
+# 5.2 完成诊断（子任务当前是焦点，直接完成）
 echo "发现问题：WebSocket 连接未正确关闭" | \
   intent-engine event add --task-id <subtask-id> --type milestone --data-stdin
-intent-engine task done <subtask-id>
+intent-engine task done
 
 # 5.3 切回并完成主任务
 intent-engine task switch 3
 # ... 修复代码 ...
-intent-engine task done 3
+intent-engine task done
 
 # 6. 生成工作报告
 intent-engine report --since 1d --summary-only
@@ -499,13 +499,13 @@ intent-engine task add --name "实现 token 刷新"
 intent-engine task add --name "实现 OAuth2"
 intent-engine task start 1
 intent-engine task spawn-subtask --name "配置 Google OAuth"
-intent-engine task done 2
+intent-engine task done  # spawn-subtask 后子任务自动成为焦点
 intent-engine task spawn-subtask --name "配置 GitHub OAuth"
-intent-engine task done 3
+intent-engine task done  # 完成当前焦点任务
 intent-engine task spawn-subtask --name "实现 token 刷新"
-intent-engine task done 4
-intent-engine task switch 1
-intent-engine task done 1
+intent-engine task done  # 完成当前焦点任务
+intent-engine task switch 1  # 切回父任务
+intent-engine task done  # 完成父任务
 ```
 
 ---

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,7 +147,7 @@ pub enum TaskCommands {
     /// - Update the task status to done
     /// - Clear the current_task_id
     ///
-    /// Prerequisites: A task must be set as current (via `current --set <ID>`)
+    ///   Prerequisites: A task must be set as current (via `current --set <ID>`)
     Done,
 
     /// Intelligently pick tasks from todo and move to doing


### PR DESCRIPTION
修改内容：
- 移除所有 `task done` 命令中的 ID 参数示例
- 强调该命令只操作当前焦点任务（current_task_id）
- 更新中文文档：
  * docs/zh-CN/guide/the-intent-engine-way.md
  * docs/zh-CN/guide/ai-quick-guide.md
- 更新英文文档：
  * docs/en/guide/the-intent-engine-way.md
  * docs/en/guide/command-reference-full.md
- 更新技能文档：
  * .claude-code/intent-engine.skill.md
- 修复 clippy 警告：src/cli.rs 文档注释格式

正确用法：
- 完成当前任务：ie task done
- 完成非当前任务：ie current --set <ID>，然后 ie task done 或：ie task switch <ID>，然后 ie task done

相关：#24 (PR v0.1.7 中引入的语义变更)