### PR TITLE
修复手动触发时 codecov 无法运行的问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   check-new-commits:
     name: Check for New Commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     outputs:
       has_new_commits: ${{ steps.check.outputs.has_new_commits }}
     steps:
@@ -72,8 +72,12 @@ jobs:
       - name: Check for commits in last 24 hours
         id: check
         run: |
-          # Check if there are any commits in the last 24 hours
-          if [ -n "$(git log --since='24 hours ago' --format='%H')" ]; then
+          # For manual triggers, always run comprehensive CI
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "🚀 Manual trigger - running comprehensive CI"
+            echo "has_new_commits=true" >> $GITHUB_OUTPUT
+          # For scheduled runs, check for new commits
+          elif [ -n "$(git log --since='24 hours ago' --format='%H')" ]; then
             echo "✅ Found new commits in the last 24 hours"
             echo "has_new_commits=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
问题：
- check-new-commits job 只在定时运行(schedule)时执行
- coverage 等 job 依赖 check-new-commits
- 手动触发(workflow_dispatch)时，check-new-commits 被跳过
- 导致 coverage job 也无法运行

修复：
- 允许 check-new-commits 在手动触发时也运行
- 手动触发时总是返回 has_new_commits=true
- 确保 coverage 等依赖的 job 能正常执行

现在手动触发 workflow 时，codecov 和其他全面测试都能正常运行。