### PR TITLE
Fix: Remove duplicate if condition in manual-build workflow

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -181,30 +181,24 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             name: linux-x64
-            enabled: ${{ inputs.platform == 'all' || inputs.platform == 'linux-x64' }}
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             name: linux-arm64
-            enabled: ${{ inputs.platform == 'all' || inputs.platform == 'linux-arm64' }}
 
           - os: macos-latest
             target: x86_64-apple-darwin
             name: macos-x64
-            enabled: ${{ inputs.platform == 'all' || inputs.platform == 'macos-x64' }}
 
           - os: macos-latest
             target: aarch64-apple-darwin
             name: macos-arm64
-            enabled: ${{ inputs.platform == 'all' || inputs.platform == 'macos-arm64' }}
 
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             name: windows-x64
-            enabled: ${{ inputs.platform == 'all' || inputs.platform == 'windows-x64' }}
 
     runs-on: ${{ matrix.os }}
-    if: matrix.enabled
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
GitHub Actions only allows one 'if' condition per job. The workflow had:
1. Job-level if (line 175-177) for build_type filtering
2. Duplicate if (line 207) for matrix.enabled - INVALID

Changes:
- Removed duplicate 'if: matrix.enabled' at line 207
- Removed unused 'enabled' field from all matrix entries
- Job now runs all matrix combinations when triggered by build_type

This fixes the workflow validation error:
"(Line: 207, Col: 5): 'if' is already defined"