### PR TITLE
fix: handle existing tags in version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -127,12 +127,24 @@ jobs:
           git add Cargo.toml Cargo.lock CLAUDE.md docs/INTERFACE_SPEC.md
           git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
 
-          git tag -a "v${{ steps.bump.outputs.version }}" -m "Release v${{ steps.bump.outputs.version }}"
+          # Delete existing tag if it exists (local and remote)
+          TAG="v${{ steps.bump.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "⚠️  Tag $TAG already exists locally, deleting..."
+            git tag -d "$TAG"
+          fi
 
+          # Try to delete remote tag (ignore error if it doesn't exist)
+          git push origin ":refs/tags/$TAG" 2>/dev/null || echo "Remote tag $TAG doesn't exist or already deleted"
+
+          # Create new tag
+          git tag -a "$TAG" -m "Release $TAG"
+
+          # Push commit and tag
           git push origin main
-          git push origin "v${{ steps.bump.outputs.version }}"
+          git push origin "$TAG"
 
-          echo "✅ Version bumped and tagged: v${{ steps.bump.outputs.version }}"
+          echo "✅ Version bumped and tagged: $TAG"
           echo "🚀 Release workflow will be triggered automatically"
 
       - name: Summary

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -135,11 +135,22 @@ if [ "$2" == "--auto" ] || [ "$2" == "-y" ]; then
     git add Cargo.toml Cargo.lock CLAUDE.md docs/INTERFACE_SPEC.md
     git commit -m "chore: bump version to $NEW_VERSION"
 
-    git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+    # Delete existing tag if it exists
+    TAG="v$NEW_VERSION"
+    if git rev-parse "$TAG" >/dev/null 2>&1; then
+        warn "Tag $TAG already exists locally, deleting..."
+        git tag -d "$TAG"
+    fi
+
+    # Try to delete remote tag (ignore error if it doesn't exist)
+    git push origin ":refs/tags/$TAG" 2>/dev/null && info "Deleted remote tag $TAG" || true
+
+    # Create new tag
+    git tag -a "$TAG" -m "Release $TAG"
 
     info "Pushing to remote..."
     git push origin main
-    git push origin "v$NEW_VERSION"
+    git push origin "$TAG"
 
     success "Release v$NEW_VERSION created and pushed!"
     echo ""


### PR DESCRIPTION
The version-bump workflow and release script now handle the case where a git tag already exists, preventing failures.

Changes:
- Check if tag exists before creating
- Delete existing local tag if found
- Delete existing remote tag if found (ignore error if doesn't exist)
- Create new tag
- Push commit and tag

This fixes the error:
  fatal: tag 'v0.1.10' already exists Error: Process completed with exit code 128

Now both the GitHub workflow and local script will:
1. Warn if tag exists
2. Delete old tag (local and remote)
3. Create fresh tag
4. Push successfully

Updated files:
- .github/workflows/version-bump.yml - Added tag existence checks
- scripts/release.sh - Added same logic for consistency