### PR TITLE
fix: use force push for tags to handle remote conflicts

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -127,22 +127,24 @@ jobs:
           git add Cargo.toml Cargo.lock CLAUDE.md docs/INTERFACE_SPEC.md
           git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
 
-          # Delete existing tag if it exists (local and remote)
+          # Handle existing tags
           TAG="v${{ steps.bump.outputs.version }}"
+
+          # Delete local tag if exists
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "⚠️  Tag $TAG already exists locally, deleting..."
             git tag -d "$TAG"
           fi
 
-          # Try to delete remote tag (ignore error if it doesn't exist)
-          git push origin ":refs/tags/$TAG" 2>/dev/null || echo "Remote tag $TAG doesn't exist or already deleted"
-
           # Create new tag
           git tag -a "$TAG" -m "Release $TAG"
 
-          # Push commit and tag
+          # Push commit
           git push origin main
-          git push origin "$TAG"
+
+          # Push tag with force to overwrite if exists remotely
+          echo "Pushing tag $TAG (will overwrite if exists)..."
+          git push -f origin "$TAG"
 
           echo "✅ Version bumped and tagged: $TAG"
           echo "🚀 Release workflow will be triggered automatically"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -135,22 +135,24 @@ if [ "$2" == "--auto" ] || [ "$2" == "-y" ]; then
     git add Cargo.toml Cargo.lock CLAUDE.md docs/INTERFACE_SPEC.md
     git commit -m "chore: bump version to $NEW_VERSION"
 
-    # Delete existing tag if it exists
+    # Handle existing tags
     TAG="v$NEW_VERSION"
+
+    # Delete local tag if exists
     if git rev-parse "$TAG" >/dev/null 2>&1; then
         warn "Tag $TAG already exists locally, deleting..."
         git tag -d "$TAG"
     fi
-
-    # Try to delete remote tag (ignore error if it doesn't exist)
-    git push origin ":refs/tags/$TAG" 2>/dev/null && info "Deleted remote tag $TAG" || true
 
     # Create new tag
     git tag -a "$TAG" -m "Release $TAG"
 
     info "Pushing to remote..."
     git push origin main
-    git push origin "$TAG"
+
+    # Push tag with force to overwrite if exists remotely
+    info "Pushing tag $TAG (will overwrite if exists)..."
+    git push -f origin "$TAG"
 
     success "Release v$NEW_VERSION created and pushed!"
     echo ""


### PR DESCRIPTION
The previous fix attempted to delete remote tags before creating new ones, but this can fail due to permissions or timing issues. Instead, use git push -f to force overwrite existing remote tags.

Changes:
- Remove attempt to delete remote tag
- Use `git push -f origin $TAG` to force push
- This works even if remote tag exists
- Simpler and more reliable approach

This fixes the error:
  ! [rejected]        v0.1.10 -> v0.1.10 (already exists)
  error: failed to push some refs
  hint: Updates were rejected because the tag already exists in the remote.

The workflow now:
1. Deletes local tag if exists
2. Creates new tag
3. Pushes commit to main
4. Force pushes tag (overwrites if exists)

Updated files:
- .github/workflows/version-bump.yml
- scripts/release.sh