### PR TITLE
Investigate Version Bump Build Issue

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -182,7 +183,7 @@ jobs:
           git push -f origin "$TAG"
 
           echo "✅ Version bumped and tagged: $TAG"
-          echo "🚀 Release workflow will be triggered automatically"
+          echo "🚀 Release workflow should be triggered automatically (requires GH_PAT secret)"
 
       - name: Summary
         run: |
@@ -195,7 +196,19 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.create_tag }}" == "true" ]; then
             echo "✅ Tag created: \`v${{ steps.bump.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "🚀 Release workflow will start shortly" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            if [ -n "${{ secrets.GH_PAT }}" ]; then
+              echo "🚀 Release workflow will start shortly" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "⚠️ **Release workflow NOT triggered** (GH_PAT secret not configured)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Manual action required:**" >> $GITHUB_STEP_SUMMARY
+              echo "1. Go to [Release Workflow](https://github.com/${{ github.repository }}/actions/workflows/release.yml)" >> $GITHUB_STEP_SUMMARY
+              echo "2. Click 'Run workflow'" >> $GITHUB_STEP_SUMMARY
+              echo "3. Enter tag: \`v${{ steps.bump.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**To fix permanently:** Add GH_PAT secret with repo scope" >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "📝 Pull request created for review" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
- Add GH_PAT token support to checkout step (fallback to GITHUB_TOKEN)
- Update summary to warn when GH_PAT is not configured
- Add manual instructions for triggering release when PAT unavailable

This fixes the issue where Version Bump with create_tag=true would not trigger the Release workflow due to GitHub Actions security limitation (GITHUB_TOKEN pushes don't trigger other workflows).