### PR TITLE
fix: update Windows console API to use Result-based interface

### DIFF
--- a/src/windows_console.rs
+++ b/src/windows_console.rs
@@ -37,9 +37,8 @@ pub fn setup_windows_console() -> Result<(), String> {
     unsafe {
         // Set console output code page to UTF-8 (65001)
         // This ensures that our UTF-8 output is correctly interpreted
-        if !SetConsoleOutputCP(65001).as_bool() {
-            return Err("Failed to set console output code page to UTF-8".to_string());
-        }
+        SetConsoleOutputCP(65001)
+            .map_err(|e| format!("Failed to set console output code page to UTF-8: {}", e))?;
 
         // Get the standard output handle
         let handle = match GetStdHandle(STD_OUTPUT_HANDLE) {


### PR DESCRIPTION
Fix compilation error on Windows due to API change in windows crate.

The SetConsoleOutputCP function now returns Result<(), Error> instead of BOOL. Update the code to use Result-based error handling:

- Before: SetConsoleOutputCP(65001).as_bool()
- After: SetConsoleOutputCP(65001).map_err(...)?

This fixes the Windows CI build while maintaining the same error handling behavior.

Fixes Windows compilation error:
  error[E0599]: no method named `as_bool` found for enum
  `std::result::Result<T, E>`