### PR TITLE
fix: update SetConsoleCP API calls for windows crate 0.58

### DIFF
--- a/src/windows_console.rs
+++ b/src/windows_console.rs
@@ -38,15 +38,13 @@ pub fn setup_windows_console() -> Result<(), String> {
     unsafe {
         // Set console INPUT code page to UTF-8 (65001)
         // This is CRITICAL for reading UTF-8 from stdin (pipes, redirects)
-        if !SetConsoleCP(65001).as_bool() {
-            return Err("Failed to set console input code page to UTF-8".to_string());
-        }
+        SetConsoleCP(65001)
+            .map_err(|e| format!("Failed to set console input code page to UTF-8: {}", e))?;
 
         // Set console OUTPUT code page to UTF-8 (65001)
         // This ensures that our UTF-8 output is correctly interpreted
-        if !SetConsoleOutputCP(65001).as_bool() {
-            return Err("Failed to set console output code page to UTF-8".to_string());
-        }
+        SetConsoleOutputCP(65001)
+            .map_err(|e| format!("Failed to set console output code page to UTF-8: {}", e))?;
 
         // Get the standard output handle
         let handle = match GetStdHandle(STD_OUTPUT_HANDLE) {


### PR DESCRIPTION
The windows crate 0.58 changed the API for SetConsoleCP and SetConsoleOutputCP to return Result<(), Error> instead of BOOL. This commit updates the calls to use proper Result handling with map_err instead of the old as_bool() method.

Error fixed:
  error[E0599]: no method named `as_bool` found for enum `std::result::Result<T, E>`
  --> src\windows_console.rs:41:33
   |
41 |         if !SetConsoleCP(65001).as_bool() {
   |                                 ^^^^^^^ method not found in Result

Changes:
- Replaced .as_bool() with .map_err() for SetConsoleCP
- Replaced .as_bool() with .map_err() for SetConsoleOutputCP
- Now provides detailed error messages including the Windows error

This ensures the code compiles on Windows with the latest windows crate.