### PR TITLE
docs: Add task_context MCP tool to INTERFACE_SPEC.md

### DIFF
--- a/docs/INTERFACE_SPEC.md
+++ b/docs/INTERFACE_SPEC.md
@@ -669,6 +669,7 @@ intent-engine current --set <TASK_ID>
 | `task_find` | Filter tasks | `task find` |
 | `task_search` | Search tasks (FTS5) | `task search` |
 | `task_get` | Get task by ID | `task get` |
+| `task_context` | Get task family tree | N/A |
 | `task_delete` | Delete task | `task delete` |
 | `event_add` | Record event | `event add` |
 | `event_list` | List events | `event list` |


### PR DESCRIPTION
The task_context tool was added to the MCP server but was missing from the interface specification document. This caused the interface_spec_test to fail.

Added task_context to the MCP tools table in section 3.2. The tool retrieves the complete family tree (ancestors, siblings, children) of a task to understand its strategic context.