### PR TITLE
fix: Correct Claude Code config path from ~/.config/claude-code to ~/…

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -186,8 +186,8 @@ cargo install --path .
 Edit Claude's MCP configuration file:
 
 **Claude Code**:
-- Linux/macOS: `~/.config/claude-code/mcp_servers.json`
-- Windows: `%APPDATA%\claude-code\mcp_servers.json`
+- Linux/macOS: `~/.claude/mcp_servers.json`
+- Windows: `%APPDATA%\Claude\mcp_servers.json`
 
 **Claude Desktop**:
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/README.md.backup
+++ b/README.md.backup
@@ -187,8 +187,8 @@ cargo install --path .
 编辑 Claude 的 MCP 配置文件:
 
 **Claude Code**:
-- Linux/macOS: `~/.config/claude-code/mcp_servers.json`
-- Windows: `%APPDATA%\claude-code\mcp_servers.json`
+- Linux/macOS: `~/.claude/mcp_servers.json`
+- Windows: `%APPDATA%\Claude\mcp_servers.json`
 
 **Claude Desktop**:
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/docs/en/integration/mcp-server.md
+++ b/docs/en/integration/mcp-server.md
@@ -51,8 +51,8 @@ sudo cp target/release/intent-engine /usr/local/bin/
 
 Edit Claude Code's MCP settings file:
 
-- **macOS/Linux**: `~/.config/claude-code/mcp_servers.json`
-- **Windows**: `%APPDATA%\claude-code\mcp_servers.json`
+- **macOS/Linux**: `~/.claude/mcp_servers.json`
+- **Windows**: `%APPDATA%\Claude\mcp_servers.json`
 
 Add Intent-Engine server configuration:
 
@@ -177,16 +177,16 @@ intent-engine mcp-server ──────> SQLite
 1. Verify MCP config file path:
    ```bash
    # Linux/macOS
-   cat ~/.config/claude-code/mcp_servers.json
+   cat ~/.claude/mcp_servers.json
 
    # Windows PowerShell
-   Get-Content $env:APPDATA\claude-code\mcp_servers.json
+   Get-Content $env:APPDATA\Claude\mcp_servers.json
    ```
 
 2. Validate JSON syntax:
    ```bash
    # Using jq to validate JSON
-   jq . ~/.config/claude-code/mcp_servers.json
+   jq . ~/.claude/mcp_servers.json
    ```
 
 3. Check binary exists and is executable:
@@ -203,10 +203,10 @@ intent-engine mcp-server ──────> SQLite
 4. Check Claude Code logs:
    ```bash
    # macOS/Linux
-   tail -f ~/.config/claude-code/logs/mcp.log
+   tail -f ~/.claude/logs/mcp.log
 
    # Windows
-   # Check %APPDATA%\claude-code\logs\
+   # Check %APPDATA%\Claude\logs\
    ```
 
 5. **Restart Claude Code** (Required!)
@@ -261,7 +261,7 @@ EOF
 
 ### Remove MCP Server Configuration
 
-1. Edit `~/.config/claude-code/mcp_servers.json`
+1. Edit `~/.claude/mcp_servers.json`
 2. Delete the `"intent-engine"` entry
 3. Restart Claude Code
 

--- a/docs/zh-CN/integration/mcp-server.md
+++ b/docs/zh-CN/integration/mcp-server.md
@@ -51,8 +51,8 @@ sudo cp target/release/intent-engine /usr/local/bin/
 
 编辑 Claude Code 的 MCP 配置文件:
 
-- **macOS/Linux**: `~/.config/claude-code/mcp_servers.json`
-- **Windows**: `%APPDATA%\claude-code\mcp_servers.json`
+- **macOS/Linux**: `~/.claude/mcp_servers.json`
+- **Windows**: `%APPDATA%\Claude\mcp_servers.json`
 
 添加 Intent-Engine 服务器配置:
 
@@ -177,16 +177,16 @@ intent-engine mcp-server ─────> SQLite
 1. 确认 MCP 配置文件路径正确:
    ```bash
    # Linux/macOS
-   cat ~/.config/claude-code/mcp_servers.json
+   cat ~/.claude/mcp_servers.json
 
    # Windows PowerShell
-   Get-Content $env:APPDATA\claude-code\mcp_servers.json
+   Get-Content $env:APPDATA\Claude\mcp_servers.json
    ```
 
 2. 验证 JSON 语法有效:
    ```bash
    # 使用 jq 验证 JSON
-   jq . ~/.config/claude-code/mcp_servers.json
+   jq . ~/.claude/mcp_servers.json
    ```
 
 3. 检查二进制文件存在且可执行:
@@ -203,10 +203,10 @@ intent-engine mcp-server ─────> SQLite
 4. 查看 Claude Code 日志:
    ```bash
    # macOS/Linux
-   tail -f ~/.config/claude-code/logs/mcp.log
+   tail -f ~/.claude/logs/mcp.log
 
    # Windows
-   # 查看 %APPDATA%\claude-code\logs\
+   # 查看 %APPDATA%\Claude\logs\
    ```
 
 5. **重启 Claude Code** (必须!)
@@ -261,7 +261,7 @@ EOF
 
 ### 移除 MCP 服务器配置
 
-1. 编辑 `~/.config/claude-code/mcp_servers.json`
+1. 编辑 `~/.claude/mcp_servers.json`
 2. 删除 `"intent-engine"` 配置项
 3. 重启 Claude Code
 

--- a/scripts/install/install-mcp-server.sh
+++ b/scripts/install/install-mcp-server.sh
@@ -19,9 +19,9 @@ echo
 
 # Set config directory based on OS
 if [ "$MACHINE" = "Mac" ] || [ "$MACHINE" = "Linux" ]; then
-    CONFIG_DIR="$HOME/.config/claude-code"
+    CONFIG_DIR="$HOME/.claude"
 elif [ "$MACHINE" = "Windows" ]; then
-    CONFIG_DIR="$APPDATA/claude-code"
+    CONFIG_DIR="$APPDATA/Claude"
 else
     echo "Unsupported OS: ${MACHINE}"
     exit 1


### PR DESCRIPTION
….claude/

The standard Claude Code configuration directory is ~/.claude/ (and %APPDATA%\Claude on Windows), not ~/.config/claude-code/.

Changes:
- Updated install script to use correct paths
- Fixed all documentation references
- Updated both English and Chinese docs
- Corrected README files

This ensures the MCP server installer creates config files in the correct location.