### PR TITLE
fix: Update MCP config path to ~/.claude.json for Claude Code v2.0.37+

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -185,9 +185,11 @@ cargo install --path .
 
 Edit Claude's MCP configuration file:
 
-**Claude Code**:
-- Linux/macOS: `~/.claude/mcp_servers.json`
-- Windows: `%APPDATA%\Claude\mcp_servers.json`
+**Claude Code** (v2.0.37+):
+- Linux/macOS/WSL: `~/.claude.json`
+- Windows: `%APPDATA%\Claude\.claude.json`
+
+> **Note**: Earlier versions may use `~/.claude/mcp_servers.json` or `~/.config/claude-code/mcp_servers.json`
 
 **Claude Desktop**:
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/README.md.backup
+++ b/README.md.backup
@@ -186,9 +186,11 @@ cargo install --path .
 
 编辑 Claude 的 MCP 配置文件:
 
-**Claude Code**:
-- Linux/macOS: `~/.claude/mcp_servers.json`
-- Windows: `%APPDATA%\Claude\mcp_servers.json`
+**Claude Code** (v2.0.37+):
+- Linux/macOS/WSL: `~/.claude.json`
+- Windows: `%APPDATA%\Claude\.claude.json`
+
+> **注意**: 早期版本可能使用 `~/.claude/mcp_servers.json` 或 `~/.config/claude-code/mcp_servers.json`
 
 **Claude Desktop**:
 - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/docs/en/integration/mcp-server.md
+++ b/docs/en/integration/mcp-server.md
@@ -51,8 +51,12 @@ sudo cp target/release/intent-engine /usr/local/bin/
 
 Edit Claude Code's MCP settings file:
 
-- **macOS/Linux**: `~/.claude/mcp_servers.json`
-- **Windows**: `%APPDATA%\Claude\mcp_servers.json`
+- **macOS/Linux**: `~/.claude.json`
+- **Windows**: `%APPDATA%\Claude\.claude.json`
+
+> **⚠️ Version Note**: Claude Code v2.0.37+ uses `~/.claude.json` as the primary config file on Linux/macOS/WSL.
+> Earlier versions may use different paths like `~/.claude/mcp_servers.json` or `~/.config/claude-code/mcp_servers.json`.
+> If MCP tools don't appear after installation, verify your Claude Code version and config file location.
 
 Add Intent-Engine server configuration:
 
@@ -176,17 +180,21 @@ intent-engine mcp-server ──────> SQLite
 **Checklist**:
 1. Verify MCP config file path:
    ```bash
-   # Linux/macOS
-   cat ~/.claude/mcp_servers.json
+   # Linux/macOS/WSL (Claude Code v2.0.37+)
+   cat ~/.claude.json
 
-   # Windows PowerShell
-   Get-Content $env:APPDATA\Claude\mcp_servers.json
+   # Windows PowerShell (Claude Code v2.0.37+)
+   Get-Content $env:APPDATA\Claude\.claude.json
+
+   # Note: Earlier versions may use different paths:
+   # - ~/.claude/mcp_servers.json
+   # - ~/.config/claude-code/mcp_servers.json
    ```
 
 2. Validate JSON syntax:
    ```bash
    # Using jq to validate JSON
-   jq . ~/.claude/mcp_servers.json
+   jq . ~/.claude.json
    ```
 
 3. Check binary exists and is executable:
@@ -261,8 +269,8 @@ EOF
 
 ### Remove MCP Server Configuration
 
-1. Edit `~/.claude/mcp_servers.json`
-2. Delete the `"intent-engine"` entry
+1. Edit `~/.claude.json` (or your version's config file)
+2. Delete the `"intent-engine"` entry from `mcpServers` section
 3. Restart Claude Code
 
 ### Uninstall Binary

--- a/docs/zh-CN/integration/mcp-server.md
+++ b/docs/zh-CN/integration/mcp-server.md
@@ -51,8 +51,12 @@ sudo cp target/release/intent-engine /usr/local/bin/
 
 编辑 Claude Code 的 MCP 配置文件:
 
-- **macOS/Linux**: `~/.claude/mcp_servers.json`
-- **Windows**: `%APPDATA%\Claude\mcp_servers.json`
+- **macOS/Linux/WSL**: `~/.claude.json`
+- **Windows**: `%APPDATA%\Claude\.claude.json`
+
+> **⚠️ 版本说明**: Claude Code v2.0.37+ 在 Linux/macOS/WSL 上使用 `~/.claude.json` 作为主配置文件。
+> 早期版本可能使用不同的路径，如 `~/.claude/mcp_servers.json` 或 `~/.config/claude-code/mcp_servers.json`。
+> 如果安装后 MCP 工具未显示，请验证您的 Claude Code 版本和配置文件位置。
 
 添加 Intent-Engine 服务器配置:
 
@@ -176,17 +180,21 @@ intent-engine mcp-server ─────> SQLite
 **检查清单**:
 1. 确认 MCP 配置文件路径正确:
    ```bash
-   # Linux/macOS
-   cat ~/.claude/mcp_servers.json
+   # Linux/macOS/WSL (Claude Code v2.0.37+)
+   cat ~/.claude.json
 
-   # Windows PowerShell
-   Get-Content $env:APPDATA\Claude\mcp_servers.json
+   # Windows PowerShell (Claude Code v2.0.37+)
+   Get-Content $env:APPDATA\Claude\.claude.json
+
+   # 注意: 早期版本可能使用不同的路径:
+   # - ~/.claude/mcp_servers.json
+   # - ~/.config/claude-code/mcp_servers.json
    ```
 
 2. 验证 JSON 语法有效:
    ```bash
    # 使用 jq 验证 JSON
-   jq . ~/.claude/mcp_servers.json
+   jq . ~/.claude.json
    ```
 
 3. 检查二进制文件存在且可执行:
@@ -261,8 +269,8 @@ EOF
 
 ### 移除 MCP 服务器配置
 
-1. 编辑 `~/.claude/mcp_servers.json`
-2. 删除 `"intent-engine"` 配置项
+1. 编辑 `~/.claude.json` (或您版本对应的配置文件)
+2. 从 `mcpServers` 部分删除 `"intent-engine"` 配置项
 3. 重启 Claude Code
 
 ### 卸载二进制文件

--- a/scripts/install/install-mcp-server.sh
+++ b/scripts/install/install-mcp-server.sh
@@ -17,17 +17,16 @@ esac
 echo "Detected OS: ${MACHINE}"
 echo
 
-# Set config directory based on OS
+# Set config file path based on OS
+# NOTE: Claude Code v2.0.37+ uses ~/.claude.json as primary config on Linux/macOS
 if [ "$MACHINE" = "Mac" ] || [ "$MACHINE" = "Linux" ]; then
-    CONFIG_DIR="$HOME/.claude"
+    MCP_CONFIG="$HOME/.claude.json"
 elif [ "$MACHINE" = "Windows" ]; then
-    CONFIG_DIR="$APPDATA/Claude"
+    MCP_CONFIG="$APPDATA/Claude/.claude.json"
 else
     echo "Unsupported OS: ${MACHINE}"
     exit 1
 fi
-
-MCP_CONFIG="$CONFIG_DIR/mcp_servers.json"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
@@ -64,7 +63,7 @@ echo "Project root: $PROJECT_ROOT"
 echo
 
 # Create config directory if it doesn't exist
-mkdir -p "$CONFIG_DIR"
+mkdir -p "$(dirname "$MCP_CONFIG")"
 
 # Create or update MCP config
 if [ -f "$MCP_CONFIG" ]; then
@@ -160,6 +159,11 @@ echo "Configuration:"
 echo "  Command: $MCP_BINARY mcp-server"
 echo "  Project: $PROJECT_ROOT"
 echo "  Config:  $MCP_CONFIG"
+echo
+echo "⚠️  Config file location notes:"
+echo "  - Claude Code v2.0.37+ uses ~/.claude.json (current default)"
+echo "  - If MCP tools don't appear, ensure you're using Claude Code v2.0.37+"
+echo "  - Config path behavior may vary across versions"
 echo
 echo "Next steps:"
 echo "  1. Restart Claude Code to load the MCP server"


### PR DESCRIPTION
Based on testing in WSL environment, Claude Code v2.0.37 uses ~/.claude.json as the primary configuration file, not ~/.claude/mcp_servers.json.

Changes:
- Updated install script to create ~/.claude.json
- Added version compatibility notes in all documentation
- Mentioned that earlier versions may use different paths
- Added warning about version-specific config behavior

Configuration reading order discovered in v2.0.37:
1. ~/.claude.json (✅ actually used)
2. ~/.claude/.config.json (❌ not implemented)
3. ~/.claude/settings.json (❌ exists but ignored)

This ensures users on current Claude Code versions can successfully install the MCP server without configuration issues.