### PR TITLE
feat: Add 'setup-mcp' command for automatic MCP server configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "which",
  "windows",
 ]
 
@@ -977,6 +978,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1447,6 +1454,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -1454,7 +1474,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1928,7 +1948,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2294,6 +2314,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2675,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber = "0.3"
 tokio = { version = "1.35", features = ["full"] }
 anyhow = "1.0"
 encoding_rs = "0.8"
+which = "6.0"
 
 # Windows console support
 [target.'cfg(windows)'.dependencies]

--- a/README.en.md
+++ b/README.en.md
@@ -169,6 +169,21 @@ Intent-Engine provides a **Rust-native MCP (Model Context Protocol) server**, en
 
 ### Quick Installation
 
+**Method 1: Automatic (Recommended)**
+
+```bash
+# Install from cargo
+cargo install intent-engine
+
+# Auto-configure MCP server for Claude Code
+intent-engine setup-mcp
+
+# Or for Claude Desktop
+intent-engine setup-mcp --target claude-desktop
+```
+
+**Method 2: From Source**
+
 ```bash
 # Clone the project
 git clone https://github.com/wayfind/intent-engine.git
@@ -178,8 +193,12 @@ cd intent-engine
 cargo install --path .
 
 # Auto-configure for Claude Code/Desktop
-./scripts/install/install-mcp-server.sh
+intent-engine setup-mcp
+# Or use the shell script:
+# ./scripts/install/install-mcp-server.sh
 ```
+
+> **Note**: The `setup-mcp` command automatically detects your OS and configures the correct file path. It targets Claude Code v2.0.37+ by default.
 
 ### Manual Configuration
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,36 @@ pub enum Commands {
         #[arg(long)]
         force: bool,
     },
+
+    /// Setup MCP server configuration for Claude Code/Desktop
+    ///
+    /// Automatically configures ~/.claude.json (or OS-specific equivalent)
+    /// to add intent-engine as an MCP server. This allows Claude Code/Desktop
+    /// to use intent-engine tools for task management.
+    ///
+    /// Run this after 'cargo install intent-engine' to complete the setup.
+    #[command(name = "setup-mcp")]
+    SetupMcp {
+        /// Show what would be done without actually doing it
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Custom config file path (default: auto-detect)
+        #[arg(long)]
+        config_path: Option<String>,
+
+        /// Project directory for INTENT_ENGINE_PROJECT_DIR env var
+        #[arg(long)]
+        project_dir: Option<String>,
+
+        /// Overwrite existing configuration
+        #[arg(long)]
+        force: bool,
+
+        /// Target application: claude-code or claude-desktop
+        #[arg(long, default_value = "claude-code")]
+        target: String,
+    },
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
Users can now run `intent-engine setup-mcp` after `cargo install` to automatically configure Claude Code/Desktop MCP integration.

Features:
- Auto-detects OS and Claude version
- Supports both Claude Code and Claude Desktop
- Automatic binary path detection
- Smart config file merging (preserves existing settings)
- Backup existing config before modification
- Dry-run mode for safe testing

Usage:
  cargo install intent-engine
  intent-engine setup-mcp                          # For Claude Code
  intent-engine setup-mcp --target claude-desktop  # For Claude Desktop
  intent-engine setup-mcp --dry-run                # Preview changes

This eliminates the need to manually run the install-mcp-server.sh script and provides a better post-install experience for cargo users.

Changes:
- Added SetupMcp command to cli.rs
- Implemented handle_setup_mcp() with OS detection
- Added get_default_config_path() for cross-platform support
- Added 'which' dependency for binary detection
- Updated README with new installation method

Fixes: Addresses the pain point of manual MCP setup after cargo install